### PR TITLE
Adding additional parameter for attach-javadocs so that it work with Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,9 @@ Authors of this POM file: iirekm, jheaton
             <goals>
               <goal>jar</goal>
             </goals>
+            <configuration>
+                <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
mvn clean package fails for maven-javadoc plugin when Java 8 is used as compiler. Follow parameter fixes it.

<configuration>
      <additionalparam>-Xdoclint:none</additionalparam>
</configuration>
